### PR TITLE
Added AMI lookups, multi-regions

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "hello-world" {
+  value = "${aws_elb.test-http.dns_name}/hello-world"
+}

--- a/services.tf
+++ b/services.tf
@@ -1,7 +1,7 @@
 resource "aws_elb" "test-http" {
     name = "test-http-elb"
     security_groups = ["${aws_security_group.load_balancers.id}"]
-    subnets = ["${aws_subnet.main.id}"]
+    subnets = ["${aws_subnet.main.*.id}"]
 
     listener {
         lb_protocol = "http"

--- a/variables.tf
+++ b/variables.tf
@@ -11,25 +11,20 @@ variable "region" {
     default = "us-east-1"
 }
 
-# TODO: support multiple availability zones, and default to it.
-variable "availability_zone" {
-    description = "The availability zone"
-    default = "us-east-1a"
+variable "cidr_block" {
+  description = "The cidr block of the VPC you would like to create"
+  default     = "10.10.0.0/16"
+}
+
+variable "az_count" {
+  description = "Number of AZs to cover in a given AWS region"
+  default     = "2"
 }
 
 variable "ecs_cluster_name" {
     description = "The name of the Amazon ECS cluster."
     default = "main"
 }
-
-variable "amis" {
-    description = "Which AMI to spawn. Defaults to the AWS ECS optimized images."
-    # TODO: support other regions.
-    default = {
-        us-east-1 = "ami-ddc7b6b7"
-    }
-}
-
 
 variable "autoscale_min" {
     default = "1"
@@ -42,16 +37,20 @@ variable "autoscale_max" {
 }
 
 variable "autoscale_desired" {
-    default = "4"
+    default = "2"
     description = "Desired autoscale (number of EC2)"
 }
-
 
 variable "instance_type" {
     default = "t2.micro"
 }
 
-variable "ssh_pubkey_file" {
-    description = "Path to an SSH public key"
-    default = "~/.ssh/id_rsa.pub"
+variable "key_name" {
+  description = "Name of AWS pub key pair for intances"
+  default = "some-key-in-aws"
+}
+
+variable "admin_cidr_ingress" {
+  description = "CIDR to allow tcp/22 ingress to EC2 instance"
+  default = "0.0.0.0/0"
 }


### PR DESCRIPTION
**  I meant multi-AZs, though the template is region-agnostic now.

Thank you for your contribution!  Attempted to finish some TODOs by adding an AMI finder and multi-AZ availability.  I would be happy to change anything back or find a better solution for something, say, relying on an existing AWS key.  