### PR TITLE
Data driven ami

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,21 @@
+data "aws_ami" "awslinux" {
+  most_recent = true
+  owners = ["amazon"]
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+output "ami_ids" {
+  value = ["${data.aws_ami.awslinux.id}"]
+}
+

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_autoscaling_group" "ecs-cluster" {
 
 resource "aws_launch_configuration" "ecs" {
     name = "ECS ${var.ecs_cluster_name}"
-    image_id = "${lookup(var.amis, var.region)}"
+    image_id = "${data.aws_ami.awslinux.id}"
     instance_type = "${var.instance_type}"
     security_groups = ["${aws_security_group.ecs.id}"]
     iam_instance_profile = "${aws_iam_instance_profile.ecs.name}"


### PR DESCRIPTION
This queries AWS by using this..

https://www.terraform.io/docs/providers/aws/d/ami.html
https://www.koding.com/docs/terraform/providers/aws/r/launch_configuration.html/

It then returns the AMI for the Amazon Linux AMI and places that into the image_id of the main.tf for launch config. 