### PR TITLE
Solve deprecation warning on roles in aws_iam_instance_profile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,5 +144,5 @@ resource "aws_iam_role_policy" "ecs_service_role_policy" {
 resource "aws_iam_instance_profile" "ecs" {
     name = "ecs-instance-profile"
     path = "/"
-    roles = ["${aws_iam_role.ecs_host_role.name}"]
+    role = "${aws_iam_role.ecs_host_role.name}"
 }


### PR DESCRIPTION
Hello I would like to present my modification to solve this deprecation warning :

`* aws_iam_instance_profile.ecs: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile`